### PR TITLE
refs #29 facebookでのユーザ登録時にメールアドレスを保存していた

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,7 +23,7 @@ class User < ActiveRecord::Base
       if user.nil?
         user = User.new(
           name: auth.extra.raw_info.name,
-          email: email ? email : "#{TEMP_EMAIL_PREFIX}-#{auth.uid}-#{auth.provider}.com",
+          email: "#{TEMP_EMAIL_PREFIX}-#{auth.uid}-#{auth.provider}.com",
           password: Devise.friendly_token[0, 20]
         )
         user.skip_confirmation!


### PR DESCRIPTION
ユーザモデルで、authに保存されているemailがあったときにそのまま保存していたので、やめた。
